### PR TITLE
Fixed session_destroy()

### DIFF
--- a/src/PHPSessionDbPg.php
+++ b/src/PHPSessionDbPg.php
@@ -95,12 +95,11 @@ class PHPSessionDbPg implements \SessionHandlerInterface
         );
         $result = pg_query_params($this->dbconn, $query, $params);
         $result_error = pg_result_error($result);
-        if ($result_error == false or (strlen($result_error) > 0)) {
+        if ($result_error === false or (strlen($result_error) > 0)) {
             return false;
         } else {
             return true;
         }
-
     }
 
     public function gc($maxlifetime = 0)


### PR DESCRIPTION
…y display the "session_destroy(): Session object destruction failed" warning message even though there weren't any error